### PR TITLE
Expanded control of speech engine when Frequency and/or Morph CV are patched

### DIFF
--- a/eurorack/plaits/dsp/voice.cc
+++ b/eurorack/plaits/dsp/voice.cc
@@ -154,10 +154,10 @@ void Voice::Render(
     internal_envelope_amplitude = 2.0f - p.harmonics * 6.0f;
     CONSTRAIN(internal_envelope_amplitude, 0.0f, 1.0f);
     speech_engine_.set_prosody_amount(
-        !modulations.trigger_patched || modulations.frequency_patched ?
+        !modulations.trigger_patched ?
             0.0f : patch.frequency_lpg_amount);
     speech_engine_.set_speed(
-        !modulations.trigger_patched || modulations.morph_patched ?
+        !modulations.trigger_patched ?
             0.0f : patch.morph_lpg_amount);
   }
 


### PR DESCRIPTION
In the original Plaits firmware, two special controls for the Speech engine (prosody and speed) are exposed via the Frequency and Morph CV attenuverters/trimpots only if the Trigger input is patched AND the Frequency or Morph CV are unpatched, respectively.

This is because these parameters are different from those controlled by the Frequency and Morph knobs (pitch and phoneme/word selection), and thus different from those which should be controlled by CV at the Frequency and Morph inputs.  So in a situation where those inputs are patched the knobs in the original hardware should revert to the expected case of attenuverting CV control over pitch and phoneme/word selection.

They are also only relevant in situations where the engine is being triggered rather than droning; although the LPG is not actually applied to this engine the controls are exposed in the same situations as the LPG modulation controls.

Given that the Poly_AudibleInstruments version of Macro Oscillator 2 provides extra trimpots, this patch allows for control of Speech engine prosody and speed via the LPG->Frequency/Morph trimpots when Trigger input is patched even when Frequency and/or Morph inputs are also patched. This allows for new possibilities such as CV modulated word selection with altered speed and prosody.