### PR TITLE
FM trimpot response when Trigger is patched and FM is unpatched

### DIFF
--- a/eurorack/plaits/dsp/voice.cc
+++ b/eurorack/plaits/dsp/voice.cc
@@ -154,10 +154,10 @@ void Voice::Render(
     internal_envelope_amplitude = 2.0f - p.harmonics * 6.0f;
     CONSTRAIN(internal_envelope_amplitude, 0.0f, 1.0f);
     speech_engine_.set_prosody_amount(
-        !modulations.trigger_patched || modulations.frequency_patched ?
+        !modulations.trigger_patched ?
             0.0f : patch.frequency_lpg_amount);
     speech_engine_.set_speed(
-        !modulations.trigger_patched || modulations.morph_patched ?
+        !modulations.trigger_patched ?
             0.0f : patch.morph_lpg_amount);
   }
 

--- a/eurorack/plaits/dsp/voice.h
+++ b/eurorack/plaits/dsp/voice.h
@@ -191,7 +191,9 @@ class Voice {
         ? (use_internal_envelope
             ? cv_modulation_amount * external_modulation + lpg_modulation_amount * envelope
             : cv_modulation_amount * external_modulation)
-        : (use_internal_envelope ? lpg_modulation_amount * envelope : cv_modulation_amount * default_internal_modulation);
+        : (use_internal_envelope 
+            ? lpg_modulation_amount * envelope + cv_modulation_amount * default_internal_modulation
+            : cv_modulation_amount * default_internal_modulation);
 
     CONSTRAIN(value, minimum_value, maximum_value);
     return value;


### PR DESCRIPTION
In the original Plaits firmware, when Trigger and Frequency CV are both unpatched, the FM trimpot attenuverts a default internal modulation of ~0.1V.

This patch allows for retaining this behavior in situations where Trigger is patched and Frequency CV is unpatched, as the LPG FM has its own trimpot rather than having to steal the existing FM trimpot.