### PR TITLE
Fix palette_push.svg

### DIFF
--- a/res/palette/palette_push.svg
+++ b/res/palette/palette_push.svg
@@ -1,27 +1,22 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- Generator: Adobe Illustrator 24.0.2, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
-<svg version="1.0" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px" width="15px"
-	 height="15px" viewBox="0 0 15 15" enable-background="new 0 0 15 15" xml:space="preserve">
-<symbol  id="New_Symbol_7" viewBox="-7.5 -7.5 15 15">
-	<g>
-		<circle fill="#414144" cx="0" cy="0" r="7.5"/>
-		<circle fill="#606266" cx="0" cy="0" r="6"/>
-	</g>
-</symbol>
-<g id="Layer_5" display="none">
-</g>
-<g id="Layer_1" display="none">
-</g>
-<g id="background">
-</g>
-<g id="print">
-</g>
-<g id="text">
-</g>
-<g id="_x31_">
-</g>
+<!-- Generator: xander mogue 20.20.6, Text Editor . SVG Version: 6.00 Build 0)  -->
+<svg
+   version="1.0"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xml:space="preserve"
+   enable-background="new 0 0 15 15"
+   viewBox="0 0 15 15"
+   height="15px"
+   width="15px"
+   y="0px"
+   x="0px">
 <g id="COMP">
-	
-		<use xlink:href="#New_Symbol_7"  width="15" height="15" x="-7.5" y="-7.5" transform="matrix(1 0 0 -1 7.5 7.5)" overflow="visible"/>
+	<g>
+		<g>
+			<circle fill="#414144" cx="7.5" cy="7.5" r="7.5"/>
+			<circle fill="#606266" cx="7.5" cy="7.5" r="6"/>
+		</g>
+	</g>
 </g>
 </svg>

--- a/res/palette/palette_pushed.svg
+++ b/res/palette/palette_pushed.svg
@@ -1,19 +1,16 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- Generator: Adobe Illustrator 24.0.2, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
-<svg version="1.0" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px" width="15px"
-	 height="15px" viewBox="0 0 15 15" enable-background="new 0 0 15 15" xml:space="preserve">
-<g id="Layer_5" display="none">
-</g>
-<g id="Layer_1" display="none">
-</g>
-<g id="background">
-</g>
-<g id="print">
-</g>
-<g id="text">
-</g>
-<g id="_x31_">
-</g>
+<svg 
+   version="1.0"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xml:space="preserve"
+   enable-background="new 0 0 15 15"
+   viewBox="0 0 15 15"
+   height="15px"
+   width="15px"
+   y="0px"
+   x="0px">
 <g id="COMP">
 	<g>
 		<g>


### PR DESCRIPTION
Inkscape's SVG output (palette_push.svg) differed from Illustrator's (palette_pushed.svg), resulting in a visual offset to push.svg when displayed in Rack. It seems to be related to Inkscape's use of the "symbol" tag rather than the g/COMP tag in SVG files. Initial attempts to adjust parameter values failed to result in a fix, so I instead entirely reformatted push.svg to match pushed.svg (using a g/COMP tag rather than symbol).